### PR TITLE
- Fix incorrect output of Perm()-function.

### DIFF
--- a/app/src/main/java/com/duy/calculator/evaluator/MathEvaluator.java
+++ b/app/src/main/java/com/duy/calculator/evaluator/MathEvaluator.java
@@ -71,7 +71,8 @@ public class MathEvaluator extends LogicEvaluator {
         String combination = "Comb(n_, k_):=(factorial(Ceiling(n)) / " + "(factorial(Ceiling(k)) * " +
                 "factorial(Ceiling(n - k))))";
         mExprEvaluator.evaluate(combination);
-        String binomial = "Perm(n_, k_):=Binomial(n, k)";
+        String binomial = "Perm(n_, k_):=(factorial(Ceiling(n)) / " +
+                "(factorial(Ceiling(n - k))))";
         mExprEvaluator.evaluate(binomial);
         String cbrt = "cbrt(x_):= x^(1/3)";
         mExprEvaluator.evaluate(cbrt);


### PR DESCRIPTION
Hi, while using the statistics functions I noticed something odd.

Both Comb(n,k) and Perm(n,k) actually return the same result (the binomial). Just that one version was explicit (using factorials) while the other directly used the Binomial-function of Symja.
Fixed by providing the correct expression for Perm(n,k) (see http://mathworld.wolfram.com/Permutation.html).

This seems to have crept in as a result of 7fa1d0eb2c013e27c8430f1df85f2767069925ec.

Maybe the intention was to replace the explicit expression for Comb(n,k) by the Binomial()-function but instead Perm(n,k) was changed.

I tested this change on a real device and the outcome is now as expected.
(e.g. Comb(3,2) is 3 and Perm(3,2) is 6)
