### PR TITLE
...the mid point of two node in mode 2D Cartesian Geometry is not correct

### DIFF
--- a/app/src/main/java/com/duy/ncalc/geom2d/line/Line2D.java
+++ b/app/src/main/java/com/duy/ncalc/geom2d/line/Line2D.java
@@ -91,7 +91,7 @@ public class Line2D extends AbstractSmoothCurve2D
     }
 
     public Line2D(com.duy.ncalc.geom2d.line.StraightLine2D mLine) {
-        this(mLine.x0, mLine.y0, mLine.dx, mLine.dy);
+        this(mLine.x0, mLine.y0, mLine.x0+mLine.dx, mLine.y0+mLine.dy);
     }
 
     /**

--- a/app/src/main/java/com/duy/ncalc/geom2d/line/Line2D.java
+++ b/app/src/main/java/com/duy/ncalc/geom2d/line/Line2D.java
@@ -91,7 +91,7 @@ public class Line2D extends AbstractSmoothCurve2D
     }
 
     public Line2D(com.duy.ncalc.geom2d.line.StraightLine2D mLine) {
-        this(mLine.x0, mLine.y0, mLine.x0+mLine.dx, mLine.y0+mLine.dy);
+        this(mLine.x0, mLine.y0, mLine.dx, mLine.dy);
     }
 
     /**

--- a/app/src/main/java/com/duy/ncalc/geom2d/line/Line2D.java
+++ b/app/src/main/java/com/duy/ncalc/geom2d/line/Line2D.java
@@ -91,7 +91,7 @@ public class Line2D extends AbstractSmoothCurve2D
     }
 
     public Line2D(com.duy.ncalc.geom2d.line.StraightLine2D mLine) {
-        this(mLine.x0, mLine.y0, mLine.dx, mLine.dy);
+        this(mLine.x0, mLine.y0, mLine.x0 + mLine.dx, mLine.y0 + mLine.dy);
     }
 
     /**


### PR DESCRIPTION
because in the class Line2D constructor is not correct. It use dx as the point2's x coordinate. So I correct it.